### PR TITLE
Align interpackage version requirements.

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -10,7 +10,7 @@ source:
     sha256: 5e7b97e557661c48f97f980b1a23594a80c13cb8fecdf0b679bb5e5cb2b65c2d
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - package:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -27,7 +27,7 @@ outputs:
         - python ${{ python_min }}.*
         - pip
         - hatchling
-        - uv-dynamic-versioning =0.7.0
+        - uv-dynamic-versioning >=0.7.0
       run:
         - python >=${{ python_min }}
         - logfire-api
@@ -57,7 +57,7 @@ outputs:
         - python ${{ python_min }}.*
         - pip
         - hatchling
-        - uv-dynamic-versioning =0.7.0
+        - uv-dynamic-versioning >=0.7.0
       run:
         - python >=${{ python_min }}
         - logfire-api
@@ -90,7 +90,7 @@ outputs:
         - python ${{ python_min }}.*
         - pip
         - hatchling
-        - uv-dynamic-versioning =0.7.0
+        - uv-dynamic-versioning >=0.7.0
       run:
         - python >=${{ python_min }}
         - pydantic-ai =${{ version }}

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -61,7 +61,7 @@ outputs:
       run:
         - python >=${{ python_min }}
         - logfire-api
-        - pydantic-graph
+        - pydantic-graph =${{ version }}
         - griffe
         - eval-type-backport
         - opentelemetry-api >=1.28.0
@@ -93,7 +93,7 @@ outputs:
         - uv-dynamic-versioning =0.7.0
       run:
         - python >=${{ python_min }}
-        - pydantic-ai
+        - pydantic-ai =${{ version }}
         - rich >=13.9.4
         - logfire-api >=1.2.0
         - pydantic >=2.10

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -27,7 +27,7 @@ outputs:
         - python ${{ python_min }}.*
         - pip
         - hatchling
-        - uv-dynamic-versioning >=0.7.0
+        - uv-dynamic-versioning =0.7.0
       run:
         - python >=${{ python_min }}
         - logfire-api
@@ -57,7 +57,7 @@ outputs:
         - python ${{ python_min }}.*
         - pip
         - hatchling
-        - uv-dynamic-versioning >=0.7.0
+        - uv-dynamic-versioning =0.7.0
       run:
         - python >=${{ python_min }}
         - logfire-api
@@ -90,7 +90,7 @@ outputs:
         - python ${{ python_min }}.*
         - pip
         - hatchling
-        - uv-dynamic-versioning >=0.7.0
+        - uv-dynamic-versioning =0.7.0
       run:
         - python >=${{ python_min }}
         - pydantic-ai =${{ version }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

I noticed that pydantic-ai 0.1.8 was installed alongside pydantic-graph 0.0.41 for me.

Currently, pydantic-ai ties the version of the packages tightly with each other. We should do the same to install the correct deps.

- pydantic-slim-ai: https://github.com/pydantic/pydantic-ai/blob/main/pydantic_ai_slim/pyproject.toml#L49
- pydantic-eval: https://github.com/pydantic/pydantic-ai/blob/main/pydantic_evals/pyproject.toml#L50