### PR TITLE
Update dependency pins

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -21,7 +21,7 @@ source:
     target_directory: pydantic-evals/
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - package:
@@ -38,7 +38,7 @@ outputs:
         - python ${{ python_min }}.*
         - pip
         - hatchling
-        - uv-dynamic-versioning
+        - uv-dynamic-versioning >=0.7.0
       run:
         - python >=${{ python_min }}
         - httpx >=0.27
@@ -70,13 +70,14 @@ outputs:
         - python ${{ python_min }}.*
         - pip
         - hatchling
-        - uv-dynamic-versioning
+        - uv-dynamic-versioning >=0.7.0
       run:
         - python >=${{ python_min }}
         - griffelib >=2.0
         - httpx >=0.27
         - pydantic >=2.12
         - pydantic-graph =${{ version }}
+        - exceptiongroup >=1.2.2
         - opentelemetry-api >=1.28.0
         - typing-inspection >=0.4.0
         - genai-prices >=0.0.48
@@ -105,19 +106,19 @@ outputs:
         - python ${{ python_min }}.*
         - pip
         - hatchling
-        - uv-dynamic-versioning
+        - uv-dynamic-versioning >=0.7.0
       run:
         - python >=${{ python_min }}
         - pydantic-ai-slim =${{ version }}
         - logfire >=4.16.0
-        - openai >=2.11.0
+        - openai >=2.29.0
         - tiktoken >=0.12.0
-        - google-genai >=1.56.0
+        - google-genai >=1.70.0
         - google-auth >=2.36.0
         - requests >=2.32.2
-        - anthropic >=0.80.0
+        - anthropic >=0.97.0
         - groq >=0.25.0
-        - boto3 >=1.42.14
+        - boto3 >=1.42.63
         - pydantic-evals =${{ version }}
         - fasta2a >=0.4.1
 
@@ -145,10 +146,10 @@ outputs:
         - python ${{ python_min }}.*
         - pip
         - hatchling
-        - uv-dynamic-versioning
+        - uv-dynamic-versioning >=0.7.0
       run:
         - python >=${{ python_min }}
-        - anyio
+        - anyio >=0
         - logfire-api >=3.14.1
         - pydantic >=2.12
         - pydantic-ai-slim =${{ version }}


### PR DESCRIPTION
- Synced dependency pins against upstream v1.95.0 metadata: [pydantic-ai/pyproject.toml](https://github.com/pydantic/pydantic-ai/blob/v1.95.0/pyproject.toml), [pydantic_ai_slim/pyproject.toml](https://github.com/pydantic/pydantic-ai/blob/v1.95.0/pydantic_ai_slim/pyproject.toml), [pydantic_graph/pyproject.toml](https://github.com/pydantic/pydantic-ai/blob/v1.95.0/pydantic_graph/pyproject.toml), and [pydantic_evals/pyproject.toml](https://github.com/pydantic/pydantic-ai/blob/v1.95.0/pydantic_evals/pyproject.toml).